### PR TITLE
Запрет на внесение в рюкзак дубликатов

### DIFF
--- a/BackPack.cs
+++ b/BackPack.cs
@@ -12,21 +12,40 @@ namespace Mountainer_s_BackPack_OOP
         static string[] items = new string[6];
         public static int error = 0;
         static List<string> glitches = new List<string>();
+        public static bool all_its_fine;
         public BackPack(string item)
-        {
-            Item = item;
-            count++;
-        }
-        public static int Count
-        {
-            get { return count; }
-        }
+        { Item = item;}
+        public static int Count =>  count;
+        public static bool All_its_fine => all_its_fine;
+
         private string Item
         {
             set
             {
-                items[count] = value;
-
+                bool SET_VALUE = false;
+                string s = value;
+                for (int i = 0; items[i] != null && i<items.Length;i++)
+                { 
+                    if (value == items[i]){SET_VALUE = true;}
+                }
+               
+                switch(SET_VALUE)
+                {
+                    case true: Console.WriteLine("Не пытайтесь нас обмануть"); all_its_fine=false; 
+                        break;
+                    case false:
+                        Proverochka_OnCorrect c= new Proverochka_OnCorrect(value);
+                        if (c.Check_Playing() == 1)
+                        {
+                            items[count] = value;
+                            Console.WriteLine("Значение прошло проверку");
+                            all_its_fine = true;
+                            count++;
+                        }
+                        else
+                        {Console.WriteLine("Не пытайтесь нас обмануть"); all_its_fine = false;}
+                        break;
+                }
             }
         }
         public static void Viewing_Ranets()
@@ -63,10 +82,6 @@ namespace Mountainer_s_BackPack_OOP
                    
             }
         }
-        //static void GameOver()
-        //{
-        //    Console.WriteLine("Игра закончена. Постарайтесь не расстроить в следующий раз ");
-        //    Thread.Sleep(1800);
-        //}
+      
     }
 }

--- a/Proverochka_OnCorrect.cs
+++ b/Proverochka_OnCorrect.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mountainer_s_BackPack_OOP
+{
+    struct Proverochka_OnCorrect
+    {
+        
+        int index_for_check;
+        string user_input;
+        
+        public Proverochka_OnCorrect( string inpt)
+        {
+            this.user_input = inpt;
+            this.index_for_check = Writing_Answers.Asking_ForIndex();
+        }
+        public int Check_Playing()
+        {
+            RightAnswers_Dictionary c = new RightAnswers_Dictionary();
+            return c.CheckValues(index_for_check, user_input);
+        }
+    }
+}

--- a/Writing_Answers.cs
+++ b/Writing_Answers.cs
@@ -12,9 +12,9 @@ namespace Mountainer_s_BackPack_OOP
         public Writing_Answers(string[] variants, int index_of_level)
         {
             Index_of_level = index_of_level;
-          Variants = variants;
-           
+            Variants = variants;   
         }
+
         static int index_of_level;
         static string[] strocka;
         static string input;
@@ -24,9 +24,9 @@ namespace Mountainer_s_BackPack_OOP
                 {
                     index_of_level = value;
                 }
-
-            } get { return index_of_level; }
+            } 
         }
+        public static int Asking_ForIndex() => index_of_level;
         private string[] Variants
         {
             set
@@ -49,17 +49,17 @@ namespace Mountainer_s_BackPack_OOP
 
         }
         public bool Osnova()
-        {       input = Console.ReadLine();
+        {      
+                input = Console.ReadLine();
                 input = input.ToLower();
-
-                RightAnswers_Dictionary c = new RightAnswers_Dictionary();
-                int result = c.CheckValues(index_of_level,input);
-                if (result == 1)
+                BackPack f1 = new BackPack($"{input}");
+               
+                if (BackPack.All_its_fine)
                 {
-                    BackPack f1 = new BackPack($"{input}");
+                   
                     Console.WriteLine($"Вы положили в рюкзак {input}");
                     
-                    switch (index_of_level)
+                    switch (Asking_ForIndex())
                     {
                      
                         case 2:
@@ -79,7 +79,7 @@ namespace Mountainer_s_BackPack_OOP
                 else
                 {
                 BackPack.Checker(); // посчёт штрафных баллов
-                    switch (index_of_level)
+                    switch (Asking_ForIndex())
                     {
                         case 1: Console.WriteLine("Не хочу чтобы ты превратился в ледышку когда шел к горе.Давай по новой");
                         break;


### PR DESCRIPTION
Добавил структуру, которая запускает метод проверки введенной пользователем строки с правильным ответом из словаря. От дубликатов избавился благодаря обыкновенному циклу и условию в BackPack.cs